### PR TITLE
typo in variable name

### DIFF
--- a/drivers/irqchip/irq-imx-irqsteer.c
+++ b/drivers/irqchip/irq-imx-irqsteer.c
@@ -194,7 +194,7 @@ static int imx_irqsteer_chans_enable(struct irqsteer_data *data)
 {
 	int ret;
 
-	ret = clk_prepare_enable(irqsteer_data->ipg_clk);
+	ret = clk_prepare_enable(data->ipg_clk);
 	if (ret) {
 		dev_err(data->dev, "failed to enable ipg clk: %d\n", ret);
 		return ret;


### PR DESCRIPTION
variable type was used instead of variable name